### PR TITLE
Support creation of single executable jar file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.iml
 resources/
 output/
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>groupId</groupId>
+    <groupId>edu.umn.morris</groupId>
     <artifactId>edn-to-csv</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
     <dependencies>
         <dependency>
             <groupId>us.bpsm</groupId>
@@ -14,5 +15,26 @@
             <version>0.5.0</version>
         </dependency>
     </dependencies>
-    
+
+    <build>
+      <plugins>
+      <plugin>
+	<artifactId>maven-assembly-plugin</artifactId>
+	<version>3.1.0</version>
+        <configuration>
+	  <archive>
+	    <manifest>
+	      <mainClass>
+		Test
+	      </mainClass>
+	    </manifest>
+	  </archive>
+	  <descriptorRefs>
+	    <descriptorRef>jar-with-dependencies</descriptorRef>
+	  </descriptorRefs>
+        </configuration>
+      </plugin>
+      </plugins>
+    </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	  <archive>
 	    <manifest>
 	      <mainClass>
-		Test
+		Main
 	      </mainClass>
 	    </manifest>
 	  </archive>

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,10 +1,15 @@
 import java.io.IOException;
 
+/**
+ * Specify the EDN source file as the first command line
+ * argument, and the directory you want the resulting CSV
+ * files to end up as the second command line argument.
+ */
 public class Main {
     public static void main(String[] args) throws IOException {
         //Make instance of the converter
         Converter Converter = new Converter();
         //To convert edn file call the convert method which takes two arguments two arguments: sourceFile and destination for the output files.
-        Converter.convert("sourceFile" ,"destinationDirectory");
+        Converter.convert(args[0], args[1]);
     }
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,6 +1,6 @@
 import java.io.IOException;
 
-public class Test {
+public class Main {
     public static void main(String[] args) throws IOException {
         //Make instance of the converter
         Converter Converter = new Converter();


### PR DESCRIPTION
This uses the `maven-assembly-plugin` to support the creation of a single executable `jar` file for the project. The generated `jar` file contains all the dependencies so you can run it using just `java -jar edn-to-csv-converter.jar` (or whatever the `jar` file is called).

I also renamed the class that has the `main()` method from `Test` (which wasn't very descriptive) to `Main`.